### PR TITLE
Add links to Fedocal and Nagios

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 This is the repository of the Fedora Status page.
 
 Upstream for this is provided at
-https://github.com:fedora-infra/statusfpo.git
+https://github.com/fedora-infra/statusfpo.git
 
 
 Setting up

--- a/wsgi/global.html
+++ b/wsgi/global.html
@@ -56,7 +56,7 @@
       </p>
       <p class="right">
         Silk Icons by <a href="http://www.famfamfam.com/lab/icons/silk/">famfamfam</a><br />
-        <a href="http://git.fedorahosted.org/git/fedora-status">Open Source</a>
+        <a href="https://github.com/fedora-infra/statusfpo">Open Source</a>
       </p>
     </div>
   </body>

--- a/wsgi/template.html
+++ b/wsgi/template.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="constraint">
-  <p align="center">(This page is manually updated with known outages)</p>
+  <p align="center">(This page is manually updated with <a href="https://apps.fedoraproject.org/calendar/list/infrastructure-outages/">known outages<a>)</p>
   {% for service in statuses %}
   <div class="content topmargin {% if statuses[service].status == "good" %} green 
                                 {% elif statuses[service].status == "scheduled" %} orange 

--- a/wsgi/template.html
+++ b/wsgi/template.html
@@ -11,7 +11,8 @@
 
 {% block content %}
 <div class="constraint">
-  <p align="center">(This page is manually updated with <a href="https://apps.fedoraproject.org/calendar/list/infrastructure-outages/">known outages<a>)</p>
+  <p align="center">(This page is manually updated with <a href="https://apps.fedoraproject.org/calendar/list/infrastructure-outages/">known outages<a>.)<br />
+  You may also check <a href="https://nagios-external.fedoraproject.org/nagios/map.php?host=all">status of our Nagios monitoring</a>.</p>
   {% for service in statuses %}
   <div class="content topmargin {% if statuses[service].status == "good" %} green 
                                 {% elif statuses[service].status == "scheduled" %} orange 


### PR DESCRIPTION
Per discussion on fedora infra mailing list, I am proposing to add links to outage calendar and Nagios monitoring.
Additionally, there are two trivial URL typo fix.