### PR TITLE
Ensure RSS feeds for all categories exist

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -41,7 +41,7 @@ AUTHOR_FEED_RSS = None
 DEFAULT_PAGINATION = False
 
 PLUGIN_PATHS = ['plugins']
-PLUGINS = ['filters', 'pelicanversion', "json_output"]
+PLUGINS = ['filters', 'pelicanversion', "json_output", "rss_missing_categories"]
 
 
 # Uncomment following line if you want document-relative URLs when developing

--- a/plugins/rss_missing_categories/__init__.py
+++ b/plugins/rss_missing_categories/__init__.py
@@ -1,0 +1,30 @@
+"""Ensure RSS feeds for all “well-known” categories are published."""
+
+from pelican import generators, signals
+
+
+class RSSMissingCategoriesGenerator(generators.ArticlesGenerator):
+    def generate_feeds(self, writer):
+        missing = {"ongoing", "planned", "resolved"} - {
+            cat.name for cat, art in self.categories
+        }
+
+        for cat in missing:
+            writer.write_feed(
+                [],  # articles
+                self.context,
+                path=f"{cat}.rss",
+                feed_title=cat,
+                feed_type="rss",
+            )
+
+    def generate_output(self, writer):
+        self.generate_feeds(writer)
+
+
+def get_generators(pelican_object):
+    return RSSMissingCategoriesGenerator
+
+
+def register():
+    signals.get_generators.connect(get_generators)


### PR DESCRIPTION
If no articles exist in a category, Pelican doesn’t know about it and won’t generate an RSS feed for it. This writes an empty feed for these categories.

Fixes: #44