### PR TITLE
fixed broken link; from cpe to infra

### DIFF
--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -33,7 +33,7 @@
 					<p class="lead">
 This is a <a class="font-weight-bold" href="https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/status-fedora/">manually updated</a> list of known
 outages. If you are experiencing issues with a service that is not listed here, please
-<a class="font-weight-bold" href="https://docs.fedoraproject.org/en-US/cpe/day_to_day_fedora/">consult the documentation</a> to determine the best way to
+<a class="font-weight-bold" href="https://docs.fedoraproject.org/en-US/infra/day_to_day_fedora/">consult the documentation</a> to determine the best way to
 raise your issue.</a>.
 					</p>
 				</div>


### PR DESCRIPTION
Changed outdated link from `https://docs.fedoraproject.org/en-US/cpe/sysadmin_guide/status-fedora/` to the updated `https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/status-fedora/`.